### PR TITLE
Added blank POST endpoint to pull a blank object for binding to forms for CREATE operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,7 @@ var meanify = require('meanify')({
 	strict: false,
 	puts: true,
 	relate: true,
-	filter: function(req) { 
-        return { public: true } 
-    },
-  }
+	filter: { public: true } 
 });
 app.use(meanify());
 ```

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Experimental feature that automatically populates references on create and remov
 ### filter
 Defines pre-set field values that allow server-enforced filtering and access control.  These field values are applied to all requests and override any values supplied for these fields in the request.
 e.g. if the filter is { public: true } then
+
 Method      | Effect of filter
 ----------- | ----------------
 SEARCH/READ | will only return resource(s) that have public = true 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ The meanify log will show the newly created endpoints.
 ```
 meanify GET    /api/users +0ms
 meanify POST   /api/users +0ms
+meanify PROPFIND    /api/users +0ms
 meanify GET    /api/users/:id +0ms
 meanify POST   /api/users/:id +0ms
 meanify DELETE /api/users/:id +0ms
 meanify GET    /api/posts +0ms
 meanify POST   /api/posts +0ms
+meanify PROPFIND    /api/posts +0ms
 meanify GET    /api/posts/:id +0ms
 meanify POST   /api/posts/:id +0ms
 meanify DELETE /api/posts/:id +0ms
@@ -196,6 +198,12 @@ Posting (or putting, if enabled) to the update route will validate the incoming 
 DELETE /{path}/{model}/{id}
 ```
 Issuing a delete request to this route will result in the deletion of the resource and a `204` response if successful. If there was no resource, a `404` will be returned.
+
+### Propfind
+```
+PROPFIND /{path}/{model}
+```
+Returns a blank object that has null for every field, or the defaultValue if one is supplied in the schema.  Does not return _id.  Does not require a request body.
 
 ## Sub-documents
 

--- a/README.md
+++ b/README.md
@@ -133,14 +133,16 @@ By default, ngResource does not support PUT for updates without [making it more 
 Experimental feature that automatically populates references on create and removes them on delete. Default: `false`
 
 ### filter
-Define pre-set field values that allow server-enforced filtering and access control.  These field values are applied to all requests and override any values supplied for these fields in the request.
-e.g. if the filter function returns { public: true } then
-SEARCH/READ: will only return resource(s) that have public = true 
-DELETE: will only work if the identified resource has public = true
-CREATE: will set public = true regardless of what data is posted
-UPDATE: will only update the identified resource if it has public = true
+Defines pre-set field values that allow server-enforced filtering and access control.  These field values are applied to all requests and override any values supplied for these fields in the request.
+e.g. if the filter is { public: true } then
+Method      | Effect of filter
+----------- | ----------------
+SEARCH/READ | will only return resource(s) that have public = true 
+DELETE      | will only work if the identified resource has public = true
+CREATE      | will set public = true regardless of what data is posted
+UPDATE      | will only update the identified resource if it has public = true
 
-public=true is a contrived example to make it easier to illustrate the mechanics.  The most likely real world usage is to supply a field value that identifies objects that the current user has access to, e.g.
+public=true is a contrived example to make it easier to illustrate the mechanics. The most likely real world usage is to supply a function returning a field value that identifies the objects that the current user has access to, e.g.
 ```
 var meanify = require('meanify')({
     filter: function(req,model) { 
@@ -148,9 +150,7 @@ var meanify = require('meanify')({
     },
 });
 ```
-In this case req.user is defined by the authentication framework (e.g. http://passportjs.org/docs/authenticate) and all models in the schema have an _owner field .
-
-To apply a filter only on certain models you can test model.modelName
+In this case req.user is defined by the authentication framework (e.g. http://passportjs.org/docs/authenticate) and all models in the schema have an _owner field.  To apply a filter only on certain models you can test model.modelName
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,11 @@ var meanify = require('meanify')({
 	caseSensitive: false,
 	strict: false,
 	puts: true,
-	relate: true
+	relate: true,
+	filter: function(req) { 
+        return { public: true } 
+    },
+  }
 });
 app.use(meanify());
 ```
@@ -127,6 +131,26 @@ By default, ngResource does not support PUT for updates without [making it more 
 
 ### relate
 Experimental feature that automatically populates references on create and removes them on delete. Default: `false`
+
+### filter
+Define pre-set field values that allow server-enforced filtering and access control.  These field values are applied to all requests and override any values supplied for these fields in the request.
+e.g. if the filter function returns { public: true } then
+SEARCH/READ: will only return resource(s) that have public = true 
+DELETE: will only work if the identified resource has public = true
+CREATE: will set public = true regardless of what data is posted
+UPDATE: will only update the identified resource if it has public = true
+
+public=true is a contrived example to make it easier to illustrate the mechanics.  The most likely real world usage is to supply a field value that identifies objects that the current user has access to, e.g.
+```
+var meanify = require('meanify')({
+    filter: function(req,model) { 
+        return { _owner: req.user.id} 
+    },
+});
+```
+In this case req.user is defined by the authentication framework (e.g. http://passportjs.org/docs/authenticate) and all models in the schema have an _owner field .
+
+To apply a filter only on certain models you can test model.modelName
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -63,13 +63,11 @@ The meanify log will show the newly created endpoints.
 ```
 meanify GET    /api/users +0ms
 meanify POST   /api/users +0ms
-meanify PROPFIND    /api/users +0ms
 meanify GET    /api/users/:id +0ms
 meanify POST   /api/users/:id +0ms
 meanify DELETE /api/users/:id +0ms
 meanify GET    /api/posts +0ms
 meanify POST   /api/posts +0ms
-meanify PROPFIND    /api/posts +0ms
 meanify GET    /api/posts/:id +0ms
 meanify POST   /api/posts/:id +0ms
 meanify DELETE /api/posts/:id +0ms
@@ -180,6 +178,7 @@ Posts.query({
 POST /{path}/{model}
 ```
 Posting (or putting, if enabled) to the create route validates the incoming data and creates a new resource in the collection. Upon validation failure, a `400` error with details will be returned to the client. On success, a status code of `201` will be issued and the new resource will be returned.
+If the POST request body is empty, a blank resource object will be returned and nothing will be written to the database.
 
 ### Read
 ```
@@ -198,12 +197,6 @@ Posting (or putting, if enabled) to the update route will validate the incoming 
 DELETE /{path}/{model}/{id}
 ```
 Issuing a delete request to this route will result in the deletion of the resource and a `204` response if successful. If there was no resource, a `404` will be returned.
-
-### Propfind
-```
-PROPFIND /{path}/{model}
-```
-Returns a blank object that has null for every field, or the defaultValue if one is supplied in the schema.  Does not return _id.  Does not require a request body.
 
 ## Sub-documents
 

--- a/meanify.js
+++ b/meanify.js
@@ -503,6 +503,7 @@ function Meanify(Model, options) {
 	for (var path in Model.schema.paths)
 	{
 		if (path == '__v') continue;
+		console.log(Model.schema.paths[path].defaultValue);
 		var def =  Model.schema.paths[path].defaultValue;
 		if (typeof def === "undefined") def = null;
 		blankDocument[path] = def;
@@ -511,7 +512,15 @@ function Meanify(Model, options) {
 	// blank url endpoint to return the blank object
 	meanify.blank = function(req, res, next)
 	{
-		res.json(blankDocument);
+		var data = {};
+		// go through the fields and evaluate any functions
+		for (var path in Model.schema.paths)
+		{
+			if (path == '__v') continue;
+			if (typeof blankDocument[path] === "function") data[path] = blankDocument[path]();
+			else data[path] = blankDocument[path];
+		}
+		res.json(data);
 	}
 }
 
@@ -574,7 +583,7 @@ module.exports = function (options) {
 			debug('PUT    ' + path);
 		}
 		router.propfind(path, meanify.blank);
-		console.log('PROPFIND    ' + path);
+		debug('PROPFIND    ' + path);
 		path += '/:id';
 		router.get(path, meanify.read);
 		debug('GET    ' + path);

--- a/meanify.js
+++ b/meanify.js
@@ -502,20 +502,20 @@ function Meanify(Model, options) {
 	var blankDocument = {};
 	for (var path in Model.schema.paths)
 	{
-		if ((path == '__v') || (path == '_id')) continue; // skip _id and __v
+		// since we'd never need to bind these to the UI, let the defaults be generated at CREATE time instead
+		if ((path == '__v') || (path == '_id')) continue; 
+		
 		var def =  Model.schema.paths[path].defaultValue;
 		if (typeof def === "undefined") def = null;
 		blankDocument[path] = def;
 	}
 
-	// blank url endpoint to return the blank object
+	// blank url endpoint to return the blank object after evaluating any functions
 	meanify.blank = function(req, res, next)
 	{
 		var data = {};
-		// go through the fields and evaluate any functions
-		for (var path in Model.schema.paths)
+		for (var path in blankDocument)
 		{
-			if (path == '__v') continue;
 			if (typeof blankDocument[path] === "function") data[path] = blankDocument[path]();
 			else data[path] = blankDocument[path];
 		}

--- a/meanify.js
+++ b/meanify.js
@@ -4,11 +4,10 @@
 	✔︎ DELETE /items/{id}
 	✔︎ GET /items
 	✔︎ GET /items/{id}
-	✔︎ POST /items
+	✔︎ POST /items (blank body returns a blank record without writing to database)
 	✔︎ PUT /items (optional)
 	✔︎ PUT /items/{id}
 	✔︎ POST /items/{id} (optional)
-	✔︎ PROPFIND /items (returns a blank record with default values or null for each field - use to databind to Create forms)
 	TODO: https://github.com/mgonto/restangular
 */
 var debug = require('debug')('meanify');
@@ -180,7 +179,11 @@ function Meanify(Model, options) {
 	};
 
 	meanify.create = function create(req, res) {
-
+		// on empty post, return blank object 
+		if (Object.keys(req.body).length === 0) {
+			return meanify.blank(req,res,null);
+		}
+		
 		Model.create(req.body, function (err, data) {
 			if (err) {
 				return res.status(400).send(err);
@@ -581,8 +584,6 @@ module.exports = function (options) {
 			router.put(path, meanify.create);
 			debug('PUT    ' + path);
 		}
-		router.propfind(path, meanify.blank);
-		debug('PROPFIND    ' + path);
 		path += '/:id';
 		router.get(path, meanify.read);
 		debug('GET    ' + path);

--- a/meanify.js
+++ b/meanify.js
@@ -502,8 +502,7 @@ function Meanify(Model, options) {
 	var blankDocument = {};
 	for (var path in Model.schema.paths)
 	{
-		if (path == '__v') continue;
-		console.log(Model.schema.paths[path].defaultValue);
+		if ((path == '__v') || (path == '_id')) continue; // skip _id and __v
 		var def =  Model.schema.paths[path].defaultValue;
 		if (typeof def === "undefined") def = null;
 		blankDocument[path] = def;

--- a/test/index.js
+++ b/test/index.js
@@ -115,13 +115,14 @@ test('Search', function (test) {
 });
 
 test('Propfind', function(test) {
-  test.plan(2);
+  test.plan(3);
   request(url + 'posts', {method:'propfind'}, function (err, res) {
     //console.log(res.body);
     var blank = JSON.parse(res.body);
     test.equal(blank.type, 'article', 'Post.type has a default value');
     var diff = Date.now() - blank.createdAt;
     test.ok(diff < 1000, "Date returned by propfind is less than 1 second ago " + blank.createdAt + " diff = " + diff);
+    test.equal(blank.title, null, "Title is null");
   })
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -117,7 +117,6 @@ test('Search', function (test) {
 test('Propfind', function(test) {
   test.plan(3);
   request(url + 'posts', {method:'propfind'}, function (err, res) {
-    //console.log(res.body);
     var blank = JSON.parse(res.body);
     test.equal(blank.type, 'article', 'Post.type has a default value');
     var diff = Date.now() - blank.createdAt;

--- a/test/index.js
+++ b/test/index.js
@@ -114,6 +114,18 @@ test('Search', function (test) {
   });
 });
 
+test('Propfind', function(test) {
+  test.plan(2);
+  request(url + 'posts', {method:'propfind'}, function (err, res) {
+    //console.log(res.body);
+    var blank = JSON.parse(res.body);
+    test.equal(blank.type, 'article', 'Post.type has a default value');
+    var diff = Date.now() - blank.createdAt;
+    test.ok(diff < 1000, "Date returned by propfind is less than 1 second ago " + blank.createdAt + " diff = " + diff);
+  })
+});
+
+
 test('Methods', function (test) {
   test.plan(5);
   request.post(url + 'posts/' + testPost._id + '/params?foo=bar', {

--- a/test/index.js
+++ b/test/index.js
@@ -114,13 +114,13 @@ test('Search', function (test) {
   });
 });
 
-test('Propfind', function(test) {
+test('Blank', function(test) {
   test.plan(3);
-  request(url + 'posts', {method:'propfind'}, function (err, res) {
+  request(url + 'posts', {method:'post'}, function (err, res) {
     var blank = JSON.parse(res.body);
     test.equal(blank.type, 'article', 'Post.type has a default value');
     var diff = Date.now() - blank.createdAt;
-    test.ok(diff < 1000, "Date returned by propfind is less than 1 second ago " + blank.createdAt + " diff = " + diff);
+    test.ok(diff < 1000, "Date returned by blank is less than 1 second ago " + blank.createdAt + " diff = " + diff);
     test.equal(blank.title, null, "Title is null");
   })
 });

--- a/test/models.js
+++ b/test/models.js
@@ -59,3 +59,10 @@ var excludedSchema = new Schema({
 });
 
 mongoose.model('Excluded', excludedSchema);
+
+var filteredSchema = new Schema({
+	name: { type: String, required: true },
+	email: { type: String, required: true }
+});
+
+mongoose.model('Filtered', filteredSchema);

--- a/test/models.js
+++ b/test/models.js
@@ -27,8 +27,8 @@ var postSchema = new Schema({
 	title: { type: String, required: true },
 	author: { type: Schema.Types.ObjectId, ref: 'User', index: true },
 	comments: [ commentSchema ],
-	type: String,
-	createdAt: Date
+	type: {type: String, default:'article'},
+	createdAt: {type: Date, default: Date.now}
 });
 
 postSchema.path('type').validate(function (value) {


### PR DESCRIPTION
I'm about to release a package that lets you generate Knockout viewmodels automatically against the meanify SCRUD endpoints.  Something missing was a way to get a blank model object for the purpose of binding against a form used for the CREATE operation.

This PROPFIND endpoint returns an object that has null for all fields in the model, except for any that have default values.  Default values that are functions will be evaluated each time.

e.g. PROPFIND /api/posts 
returns { title:null,author:null ... }

PROPFIND is an 'extension method' under the http spec (https://tools.ietf.org/html/rfc2616) and is one of the routing methods supported by express (http://expressjs.com/guide/routing.html).  Happy to change to a different endpoint if you think it makes more sense (e.g. GET /api/posts/__blank or something?)
